### PR TITLE
fix: added `ignore_permissions` to `delete_fixtures`

### DIFF
--- a/frappe_testing/test_fixture.py
+++ b/frappe_testing/test_fixture.py
@@ -103,7 +103,14 @@ class TestFixture():
                 doc.reload()
                 if doc.docstatus == 1:
                     doc.cancel()
-                frappe.delete_doc(dt, doc.name, force=not meta.is_submittable)
+
+                frappe.delete_doc(
+                    dt,
+                    doc.name,
+                    force=not meta.is_submittable,
+                    ignore_permissions=True
+                )
+
         self.fixtures = frappe._dict()
 
     def __getitem__(self, doctype_idx):


### PR DESCRIPTION
This PR adds `ignore_permissions=True` to `delete_fixtures`, so that errors related to permissions don't occur during `tearDown`, leading to an easier testing environment.