### PR TITLE
fix: added `ignore_permissions` when cancelling a doc during `tearDown`

### DIFF
--- a/frappe_testing/test_fixture.py
+++ b/frappe_testing/test_fixture.py
@@ -102,7 +102,8 @@ class TestFixture():
 
                 doc.reload()
                 if doc.docstatus == 1:
-                    doc.cancel()
+                    doc.docstatus = 2
+                    doc.save(ignore_permissions=True)
 
                 frappe.delete_doc(
                     dt,


### PR DESCRIPTION
Similar to #1, this PR adds `ignore_permissions` this time to cancelling docs, so that errors related to permissions don't occur during `tearDown`, leading to an easier testing environment.